### PR TITLE
Fix/make query more robust

### DIFF
--- a/src/Dan.Plugin.Kartverket/Clients/ar50/Ar5repo.cs
+++ b/src/Dan.Plugin.Kartverket/Clients/ar50/Ar5repo.cs
@@ -74,11 +74,11 @@ namespace Dan.Plugin.Kartverket.Clients.ar50
                         WITH eiendom AS (
                         SELECT CASE
                             WHEN ST_GeometryType(
-                                ST_Transform(ST_SetSRID(ST_GeomFromText(`@geom`), 4326), 25833)
+                                ST_Transform(ST_SetSRID(ST_GeomFromText(@geom), 4326), 25833)
                             ) = 'ST_Polygon'
-                        THEN ST_Transform(ST_SetSRID(ST_GeomFromText(`@geom`), 4326), 25833)
+                        THEN ST_Transform(ST_SetSRID(ST_GeomFromText(@geom), 4326), 25833)
                         ELSE ST_Buffer(
-                            ST_Transform(ST_SetSRID(ST_GeomFromText(`@geom`), 4326), 25833),
+                            ST_Transform(ST_SetSRID(ST_GeomFromText(@geom), 4326), 25833),
                             0
                         )
                         END AS shape

--- a/src/Dan.Plugin.Kartverket/Clients/ar50/Ar5repo.cs
+++ b/src/Dan.Plugin.Kartverket/Clients/ar50/Ar5repo.cs
@@ -71,47 +71,41 @@ namespace Dan.Plugin.Kartverket.Clients.ar50
             //4326 is the Spatial Reference System Identifier (SRID) for WGS 84,
             //4258 is the EPSG coordinate reference system used for the returned GeoJSON coordinates.
             string sql = @"
-                        WITH input_geom AS (
-                        SELECT ST_Transform(
-                            ST_SetSRID(ST_GeomFromText(@geom), 4326),
-                            25833
-                        ) AS geom
-                    ),
-
-                    -- 🔹 Finn relevante AR5 grenser rundt input
-                    grenser AS (
-                        SELECT g.shape
-                        FROM fkb_ar5_grense g
-                        JOIN input_geom i
-                            ON ST_Intersects(g.shape, i.geom)
-                    ),
-
-                    -- 🔹 Bygg polygon(er) fra grensene (inkludert hull)
-                    eiendom AS (
-                        SELECT ST_BuildArea(ST_Union(shape)) AS shape
-                        FROM grenser
-                    ),
-
-                    -- 🔹 Klipp AR5-områder mot eiendommen
-                    intersections AS (
+                        WITH geom AS (
                         SELECT
-                            o.objectid,
-                            o.arealtype,
-                            o.shape AS original_geom,
-                            ST_Intersection(o.shape, e.shape) AS geom
-                        FROM fkb_ar5_omrade o
-                        JOIN eiendom e
-                            ON ST_Intersects(o.shape, e.shape)
+                            CASE
+                                WHEN ST_GeometryType(
+                                    ST_Transform(ST_SetSRID(ST_GeomFromText(@geom), 4326), 25833)
+                                ) = 'ST_Polygon'
+                                    THEN ST_Transform(ST_SetSRID(ST_GeomFromText(@geom), 4326), 25833)
+                                ELSE ST_Buffer(
+                                    ST_Transform(ST_SetSRID(ST_GeomFromText(@geom), 4326), 25833),
+                                    1
+                                )
+                            END AS geom
+                    ),
+
+                    eiendom AS (
+                        SELECT ST_BuildArea(ST_Union(g.shape)) AS shape
+                        FROM fkb_ar5_grense g
+                        JOIN geom i
+                            ON ST_DWithin(g.shape, i.geom, 1)
                     )
 
                     SELECT
-                        objectid AS ""Objectid"",
-                        arealtype AS ""ArealType"",
-                        ST_Area(geom) AS ""ClippedArea"",
-                        ST_AsGeoJSON(ST_Transform(geom, 4258)) AS ""GeoJson""
-                    FROM intersections
-                    WHERE 
-                        NOT ST_IsEmpty(geom)";
+                        o.objectid AS ""Objectid"",
+                        o.arealtype AS ""ArealType"",
+                        ST_Area(ST_Intersection(o.shape, e.shape)) AS ""ClippedArea"",
+                        ST_AsGeoJSON(
+                            ST_Transform(
+                                ST_Intersection(o.shape, e.shape),
+                                4258
+                            )
+                        ) AS ""GeoJson""
+                    FROM fkb_ar5_omrade o
+                    JOIN eiendom e
+                        ON ST_Intersects(o.shape, e.shape)
+                    WHERE NOT ST_IsEmpty(ST_Intersection(o.shape, e.shape));";
 
             var results = (await connection.QueryAsync<Ar5OmradeDbModel>(
                 sql,

--- a/src/Dan.Plugin.Kartverket/Clients/ar50/Ar5repo.cs
+++ b/src/Dan.Plugin.Kartverket/Clients/ar50/Ar5repo.cs
@@ -71,37 +71,47 @@ namespace Dan.Plugin.Kartverket.Clients.ar50
             //4326 is the Spatial Reference System Identifier (SRID) for WGS 84,
             //4258 is the EPSG coordinate reference system used for the returned GeoJSON coordinates.
             string sql = @"
-                        WITH eiendom AS (
-                        SELECT CASE
-                            WHEN ST_GeometryType(
-                                ST_Transform(ST_SetSRID(ST_GeomFromText(@geom), 4326), 25833)
-                            ) = 'ST_Polygon'
-                        THEN ST_Transform(ST_SetSRID(ST_GeomFromText(@geom), 4326), 25833)
-                        ELSE ST_Buffer(
-                            ST_Transform(ST_SetSRID(ST_GeomFromText(@geom), 4326), 25833),
-                            0
-                        )
-                        END AS shape
+                        WITH input_geom AS (
+                        SELECT ST_Transform(
+                            ST_SetSRID(ST_GeomFromText(@geom), 4326),
+                            25833
+                        ) AS geom
                     ),
+
+                    -- 🔹 Finn relevante AR5 grenser rundt input
+                    grenser AS (
+                        SELECT g.shape
+                        FROM fkb_ar5_grense g
+                        JOIN input_geom i
+                            ON ST_Intersects(g.shape, i.geom)
+                    ),
+
+                    -- 🔹 Bygg polygon(er) fra grensene (inkludert hull)
+                    eiendom AS (
+                        SELECT ST_BuildArea(ST_Union(shape)) AS shape
+                        FROM grenser
+                    ),
+
+                    -- 🔹 Klipp AR5-områder mot eiendommen
                     intersections AS (
                         SELECT
                             o.objectid,
                             o.arealtype,
+                            o.shape AS original_geom,
                             ST_Intersection(o.shape, e.shape) AS geom
                         FROM fkb_ar5_omrade o
                         JOIN eiendom e
                             ON ST_Intersects(o.shape, e.shape)
                     )
+
                     SELECT
                         objectid AS ""Objectid"",
                         arealtype AS ""ArealType"",
                         ST_Area(geom) AS ""ClippedArea"",
                         ST_AsGeoJSON(ST_Transform(geom, 4258)) AS ""GeoJson""
                     FROM intersections
-                    -- ST_Area(geom) > 10 - Threshold of 10 m² filters out topology slivers from ST_Intersection
                     WHERE 
-                        NOT ST_IsEmpty(geom)
-                        AND ST_Area(geom) > 10;";
+                        NOT ST_IsEmpty(geom)";
 
             var results = (await connection.QueryAsync<Ar5OmradeDbModel>(
                 sql,


### PR DESCRIPTION
### Description
<!--- What and why -->
Masking holes in geometry so they are not part of the property in sql query.
### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved geographical area boundary intersection queries to use enhanced geometry processing. The calculation now correctly handles area clipping and intersection logic without applying previous area size filters, ensuring more accurate results when querying cadastral data boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->