### PR TITLE
Eduediligence use their own credentials instead of OED credentials

### DIFF
--- a/src/Dan.Plugin.Kartverket/Clients/Grunnbok/GrunnbokHelpers.cs
+++ b/src/Dan.Plugin.Kartverket/Clients/Grunnbok/GrunnbokHelpers.cs
@@ -62,8 +62,8 @@ namespace Dan.Plugin.Kartverket.Clients.Grunnbok
             }
             else if(serviceContext.ToUpper() == "EDUEDILIGENCE")
             {
-                credentials.UserName.UserName = settings.MatrikkelUser;
-                credentials.UserName.Password = settings.MatrikkelPw;
+                credentials.UserName.UserName = settings.MatrikkelEDueDiligenceUser;
+                credentials.UserName.Password = settings.MatrikkelEDueDiligencePw;
             }
             else if(serviceContext.ToUpper() == "OED"|| serviceContext.ToUpper() == "DIGITALDODSBO")
             {


### PR DESCRIPTION
### Description
<!--- What and why -->
Eduediligence have been using matrikkelPw/matrikkelUser instead of their own dedicated credentials. This is fixed now

### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated credential configuration handling for enterprise service integrations to use dedicated settings, improving system stability and security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/data-altinn-no/plugin-kartverket/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->